### PR TITLE
Bug Fix: Do not increment self.packets on chat messages

### DIFF
--- a/ys_proto.py
+++ b/ys_proto.py
@@ -255,6 +255,10 @@ class Apps:
         elif type == 32:
             msg = self.ysrcv.msg(buffer)[1].decode('utf-8', errors='ignore')
             logger.info("message " + msg)
+            # A message from a server maybe player generated and does not
+            # contribute to any in-game infomation, avoid incrementing
+            # the packet count, as this is not progress.
+            self.packets -= 1
         elif type == 33:
             self.server.weather = self.ysrcv.weather(buffer)
             opts = bin(self.server.weather[1])


### PR DESCRIPTION
Hello Eric,
YSFlight servers may send player-generated chat messages or messages from the server, which are just text messages and they do not contain any in-game information. This should be ignored and self.packets shouldn't be incremented.

Currently, when the server sends multiple chat messages (such as multi-line welcome message, announcements, etc) it will incorrectly increment the self.packets counter, causing misinterpretation of the player list in server.